### PR TITLE
Failure exit when tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,15 @@ node_js:
   # so that your addon works for all apps
   - "4"
 
-sudo: false
+sudo: required
 dist: trusty
 
 addons:
   chrome: stable
+
+before_script:
+  - "sudo chown root /opt/google/chrome/chrome-sandbox"
+  - "sudo chmod 4755 /opt/google/chrome/chrome-sandbox"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,4 @@ script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup
+  - npm test

--- a/index.js
+++ b/index.js
@@ -17,7 +17,12 @@ module.exports = {
           let config = require(`${this.project.root}/.doorkeeperrc`);
           this.ui.writeLine('Running tests ...');
           this.ui.writeLine(config.testCommand);
-          runTestCommand(config.testCommand);
+          let resp = runTestCommand(config.testCommand);
+          if (resp.code !== 0) {
+            this.ui.writeLine("We'll run code coverage when your tests pass.");
+            process.exit(1);
+            return;
+          }
 
           let oldCoverage = getCoverage(config.mainBranch);
 

--- a/src/run-test-command.js
+++ b/src/run-test-command.js
@@ -3,5 +3,5 @@
 const shell = require('shelljs');
 
 module.exports = function runTestCommand(testCommand) {
-  shell.exec(testCommand);
+  return shell.exec(testCommand);
 }


### PR DESCRIPTION
We noticed that CircleCI was passing the build when tests failed since it wasn't checking the test command exit status.